### PR TITLE
Add check for required binaries

### DIFF
--- a/kapow-setup/kapow.sh
+++ b/kapow-setup/kapow.sh
@@ -4,6 +4,10 @@
 
 echo "$(tput setaf 2)Initialising Kapow! Setup script...$(tput setaf 9)"
 
+hash git 2>&- || { echo >&2 "Git is required but missing. Exiting."; exit 1; }
+hash unzip 2>&- || { echo >&2 "Unzip is required but missing. Exiting."; exit 1; }
+hash curl 2>&- || { echo >&2 "cURL is required but missing. Exiting."; exit 1; }
+
 # Input variables
 if [ "$1" = "develop" ]
 	# Assume first argument is a branch


### PR DESCRIPTION
I've added a check for `git`, `unzip` and `curl`. When I ran the script on the Linux Subsystem in Windows 10 it failed without much explanation as any failures that occur during the unzip process are swallowed.

Could probably do with adding more for `vagrant`, `bower`, `composer` and `grunt`.

*For review by @davetgreen @mwtsn*
